### PR TITLE
Fix titles for site and summary

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -2,7 +2,6 @@
 
 baseurl = "http://example.org/"
 languageCode = "en-us"
-title = "John Doe Resume"
 theme = "hugo-orbit-theme"
 googleAnalytics = "UA-XXXXXXX-Y"
 
@@ -16,6 +15,7 @@ disable404 = true
 # Meta
     description = "Hugo Responsive Resume/CV Theme for Developers"
     author = "Pavel Kanyshev"
+    title = "John Doe Resume"
 
 # Theme styles
 

--- a/layouts/partials/summary.html
+++ b/layouts/partials/summary.html
@@ -1,5 +1,5 @@
             <section class="section summary-section">
-                <h2 class="section-title"><i class="fa {{ .Site.Params.summary.icon }}"></i>{{ i18n "summary" }}</h2>
+                <h2 class="section-title"><i class="fa {{ .Site.Params.summary.icon }}"></i>{{ .Site.Params.summary.title }}</h2>
                 <div class="summary">
                     <p>{{ with .Site.Params.summary.summary }}{{ . | markdownify }}{{ end }}</p>
                 </div><!--//summary-->


### PR DESCRIPTION
- head.html calls for site.params.title, which is in the wrong place by default
- summary.html calls i18n instead of pulling from config.toml